### PR TITLE
Update NestedStorable.php Fix for Laravel: 11.3.1

### DIFF
--- a/src/Fields/NestedStorable.php
+++ b/src/Fields/NestedStorable.php
@@ -336,7 +336,7 @@ trait NestedStorable
 
         $createRequest['editMode'] = 'create';
 
-        $createRequest->files->replace($request->file("{$this->attribute}.{$index}") ?? []);
+        $createRequest->files->replace($request->file("{$this->attribute}.{$index}", []));
 
         return (new ResourceStoreController())->__invoke($createRequest);
     }
@@ -361,7 +361,7 @@ trait NestedStorable
 
         $updateRequest->route()->setParameter('resourceId', $child['model']->getKey());
 
-        $updateRequest->files->replace($request->file("{$this->attribute}.{$index}") ?? []);
+        $updateRequest->files->replace($request->file("{$this->attribute}.{$index}", []));
 
         return (new ResourceUpdateController())->__invoke($updateRequest);
     }

--- a/src/Fields/NestedStorable.php
+++ b/src/Fields/NestedStorable.php
@@ -336,7 +336,7 @@ trait NestedStorable
 
         $createRequest['editMode'] = 'create';
 
-        $createRequest->files = collect($request->file("{$this->attribute}.{$index}"));
+        $createRequest->files->replace($request->file("{$this->attribute}.{$index}") ?? []);
 
         return (new ResourceStoreController())->__invoke($createRequest);
     }
@@ -361,7 +361,7 @@ trait NestedStorable
 
         $updateRequest->route()->setParameter('resourceId', $child['model']->getKey());
 
-        $updateRequest->files = collect($request->file("{$this->attribute}.{$index}"));
+        $updateRequest->files->replace($request->file("{$this->attribute}.{$index}") ?? []);
 
         return (new ResourceUpdateController())->__invoke($updateRequest);
     }


### PR DESCRIPTION
fix error for 
Laravel: 11.3.1 
laravel/nova 4.33.3


exception:  "TypeError"
file: "vendor/lupennat/nova-nested-many/src/Fields/NestedStorable.php"
line: 340
message: "Cannot assign Illuminate\\Support\\Collection to property Symfony\\Component\\HttpFoundation\\Request::$files of type Symfony\\Component\\HttpFoundation\\FileBag"